### PR TITLE
Added support of the HTML5 download attribute

### DIFF
--- a/jquery.multiDownload.js
+++ b/jquery.multiDownload.js
@@ -19,6 +19,7 @@
                 group = null;
             }
 
+            var type = (options && options.type) || "iframe";
             var triggerDelay = (options && options.delay) || 100;
             var cleaningDelay = (options && options.cleaningDelay) || 1000;
             var elements = $('.' + methods._itemClass(group));
@@ -28,11 +29,33 @@
             triggers.bind(event, function (e) {
                 e.preventDefault();
                 elements.each(function (index, link) {
-                    methods._createIFrame(link, index * triggerDelay, cleaningDelay);
+                    if(type == "adownload")
+                        methods._createADownload(link, index * triggerDelay, cleaningDelay);
+                    else
+                        methods._createIFrame(link, index * triggerDelay, cleaningDelay);
                 });
             });
 
             return this;
+        },
+        
+        _createADownload: function(link, triggerDelay, cleaningDelay) {
+            var url = $(link).attr('href');
+            //using the last section of the url for the name not always works so having the name set in the data attribute is mandatory
+            var name = $(link).data("name");
+            if(!name) {
+                methods._createIFrame(link, triggerDelay, cleaningDelay);
+                return;
+            }   
+            try {
+                var aelement = document.createElement('a');
+                aelement.download = name;
+                aelement.href = url;
+                aelement.click();
+            }
+            catch(e) {
+                methods._createIFrame(link, triggerDelay, cleaningDelay);
+            }
         },
 
         _createIFrame: function (link, triggerDelay, cleaningDelay) {


### PR DESCRIPTION
Added support of the HTML5 download attribute. When used on an anchor,
this attribute signifies that the resource it points to should be
downloaded by the browser rather than navigating to it. This eliminates
the problem of using IFRAME for PDF files which are opened by Chrome and
Firefox instead of downloaded.

It is currently supporte only on latest Chrome and Firefox, so in the
implementation when it is detected that the browser does not support
this feature, a fallback to IFRAME is used. (line 57)

For this feature to be used two things must be specified:
1. Option "type" set to "adownload": $("#button").multiDownload('click',
{type: "adownload"});
2. Elements with href must have a data attribrute "data-name" storing
the name of the file to be downloaded:
<a href="../fileone.pdf" data-name="fileone.pdf">

<a href="../servefiles.php?fileid=12345" data-name="filetwo.pdf">

The need of the "data-name" attribute is because the value of the
"download" attribute sets the name to be used when downloading the file
which is not always possible to infer from the url.

Sample of the a-download in action:
http://html5-demos.appspot.com/static/a.download.html
