### PR TITLE
Allow user to pass in onload event for error handling

### DIFF
--- a/jquery.multiDownload.js
+++ b/jquery.multiDownload.js
@@ -4,19 +4,19 @@
         _download: function (options) {
             var triggerDelay = (options && options.delay) || 100;
             var cleaningDelay = (options && options.cleaningDelay) || 1000;
-            var onloadEvent = (options && options.onloadEvent) || "";
+            var onLoadHandler = (options && options.onLoadHandler);
 
             this.each(function (index, item) {
-                methods._createIFrame(item, index * triggerDelay, cleaningDelay, onloadEvent);
+                methods._createIFrame(item, index * triggerDelay, cleaningDelay, onLoadHandler);
             });
             return this;
         },
 
-        _createIFrame: function (item, triggerDelay, cleaningDelay, onloadEvent) {
+        _createIFrame: function (item, triggerDelay, cleaningDelay, onLoadHandler) {
             setTimeout(function () {
                 var frame = $('<iframe style="display: none;" class="multi-download-frame"></iframe>');
-                if(onloadEvent != "") {
-                    frame = $('<iframe style="display: none;" onload="' + onloadEvent + '(this);"  class="multi-download-frame"></iframe>');
+                if(onLoadHandler) {
+                    frame.on('load', onLoadHandler)
                 }
                 frame.attr('src', $(item).attr('href') || $(item).attr('src'));
                 $(item).after(frame);


### PR DESCRIPTION
In order to check the status of the iframes created it would be nice to have access to the iframe's onload event by passing in a function. 
Tests still pass and if you have any requests for changes just let me know!
